### PR TITLE
#49: Semantics of getLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ As of version 1.0.0, the project will try and follow [Semantic Versioning](https
 
 ## [Unreleased]
 
+### Topology, Node and Link classes modifications
+
+[[issue 49]][issue: #49]
+
+* The enum class `Link.Type` has been **renamed** as `Link.Orientation`.
+
+* The enum class `Link.DEFAULT_TYPE` has been **renamed** into `Link.DEFAULT_ORIENTATION`.
+
+* The class `Topology` is augmented with an instance variable `orientation` that contains the default orientation of 
+the topology. Accessors/Actuators have been added as `Topology.setOrientation()` and `Topology.getOrientation()`.
+
+* A new helper method is added `Topology.isDirected()` that is a simple test of the value returned by 
+`Topology.getOrientation()`.  
+
+* Accessors to links `Topology.getLinks()`, `Topology.getLink()` and `Node.getLinks()` now return links whose type is 
+determined with respect to `Topology.getOrientation()`.
+
+* Accessors to links based on a Boolean specification of the orientation i.e., `Topology.getLinks(boolean)`, 
+`Topology.getLink(Node,Node,boolean)` and `Node.getLinks(boolean)` are marked **deprecated** and replaced by methods 
+where the Boolean is replaced by a `Link.Orientation` parameter.  
+ 
+* The method `Topology.hasDirectedLinks()` is marked as **deprecated**; `Topology.isDirected()` should be used instead.
+
+* Implementation of `Node.getCommonLinkWith()` and `Node.getNeighbors()` is changed to explicitly request undirected 
+links. 
+  
+* Add a test suite to check behaviors of `Topology.getLinks()` w.r.t. topology orientation.
+
+[issue: #49]: https://github.com/jbotsim/JBotSim/issues/49
 
 ### Javadoc modifications 
 

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ subprojects {
     dependencies{
         testImplementation(
                 'org.junit.jupiter:junit-jupiter-api:5.1.0',
+                'org.junit.jupiter:junit-jupiter-params:5.1.0',
                 "junit:junit:4+"
         )
         testRuntimeOnly(

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Link.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Link.java
@@ -28,24 +28,24 @@ import java.util.List;
 /**
  * <p>The {@link Link} object encodes a communication link between two {@link Node}s.</p>
  *
- * <p>Links can either be {@link Type#DIRECTED} or {@link Type#UNDIRECTED}, and either
+ * <p>Links can either be {@link Orientation#DIRECTED} or {@link Orientation#UNDIRECTED}, and either
  * {@link Mode#WIRED} or {@link Mode#WIRELESS}.
- * The by default, a link will be {@link Type#UNDIRECTED} and {@link Mode#WIRELESS}.</p>
+ * The by default, a link will be {@link Orientation#UNDIRECTED} and {@link Mode#WIRELESS}.</p>
  */
 public class Link extends Properties implements Comparable<Link> {
     public static final Color DEFAULT_COLOR = Color.darkGray;
     public static final int DEFAULT_WIDTH = 1;
-    public static final Type DEFAULT_TYPE = Type.UNDIRECTED;
+    public static final Orientation DEFAULT_ORIENTATION = Orientation.UNDIRECTED;
     public static final Mode DEFAULT_MODE = Mode.WIRED;
 
     Integer width = DEFAULT_WIDTH;
     Color color = DEFAULT_COLOR;
 
     /**
-     * Enumerates the two possible types of a link: <code>Type.DIRECTED</code> and
-     * <code>Type.UNDIRECTED</code>.
+     * Enumerates the two possible types of a link: <code>Orientation.DIRECTED</code> and
+     * <code>Orientation.UNDIRECTED</code>.
      */
-    public enum Type {
+    public enum Orientation {
         DIRECTED, UNDIRECTED
     }
 
@@ -68,9 +68,9 @@ public class Link extends Properties implements Comparable<Link> {
      */
     public Node destination;
     /**
-     * The <code>Type</code> of this link (directed/undirected)
+     * The <code>Orientation</code> of this link (directed/undirected)
      */
-    public Type type;
+    public Orientation orientation;
     /**
      * The <code>Mode</code> of this link (wired/wireless)
      */
@@ -83,21 +83,21 @@ public class Link extends Properties implements Comparable<Link> {
      * @param n2 The destination node.
      */
     public Link(Node n1, Node n2) {
-        this(n1, n2, DEFAULT_TYPE, DEFAULT_MODE);
+        this(n1, n2, DEFAULT_ORIENTATION, DEFAULT_MODE);
     }
 
     /**
-     * Creates a wired link of the specified <code>type</code> between the nodes
+     * Creates a wired link of the specified <code>orientation</code> between the nodes
      * <code>from</code> and <code>to</code>. The respective order of <code>from</code>
-     * and <code>to</code> does not matter if the specified type is undirected.
+     * and <code>to</code> does not matter if the specified orientation is undirected.
      *
      * @param from The source node.
      * @param to   The destination node.
-     * @param type The type of the link (<code>Type.DIRECTED</code> or
-     *             <code>Type.UNDIRECTED</code>).
+     * @param orientation The orientation of the link (<code>Orientation.DIRECTED</code> or
+     *             <code>Orientatino.UNDIRECTED</code>).
      */
-    public Link(Node from, Node to, Type type) {
-        this(from, to, type, DEFAULT_MODE);
+    public Link(Node from, Node to, Orientation orientation) {
+        this(from, to, orientation, DEFAULT_MODE);
     }
 
     /**
@@ -112,26 +112,26 @@ public class Link extends Properties implements Comparable<Link> {
      *             <code>Mode.WIRELESS</code>).
      */
     public Link(Node from, Node to, Mode mode) {
-        this(from, to, DEFAULT_TYPE, mode);
+        this(from, to, DEFAULT_ORIENTATION, mode);
     }
 
     /**
-     * Creates a link of the specified <code>type</code> with the specified
+     * Creates a link of the specified <code>orientation</code> with the specified
      * <code>mode</code> between the nodes from and to. The created link is wired
      * by default. The respective order of <code>from</code> and <code>to</code> does
-     * not matter if the type is undirected.
+     * not matter if the orientation is undirected.
      *
      * @param from The source node.
      * @param to   The destination node.
-     * @param type The type of the link (<code>Type.DIRECTED</code> or
-     *             <code>Type.UNDIRECTED</code>).
+     * @param orientation The orientation of the link (<code>Orientation.DIRECTED</code> or
+     *             <code>Orientation.UNDIRECTED</code>).
      * @param mode The mode of the link (<code>Mode.WIRED</code> or
      *             <code>Mode.WIRELESS</code>).
      */
-    public Link(Node from, Node to, Type type, Mode mode) {
+    public Link(Node from, Node to, Orientation orientation, Mode mode) {
         source = from;
         destination = to;
-        this.type = type;
+        this.orientation = orientation;
         this.mode = mode;
     }
 
@@ -230,17 +230,17 @@ public class Link extends Properties implements Comparable<Link> {
     }
 
     /**
-     * Tests whether the <code>type</code> is DIRECTED.
-     * @return <code>true</code> if the link <code>type</code> is DIRECTED,
+     * Tests whether the <code>orientation</code> is DIRECTED.
+     * @return <code>true</code> if the link <code>orientation</code> is DIRECTED,
      *         <code>false</code> otherwise.
      */
     public boolean isDirected() {
-        return type == Type.DIRECTED;
+        return orientation == Orientation.DIRECTED;
     }
 
     /**
      * Compares the specified object with this link for equality. Returns
-     * <code>true</code> if both links have the same <code>type</code>
+     * <code>true</code> if both links have the same <code>orientation</code>
      * (directed/undirected) and the same endpoints (interchangeably if
      * undirected). The <code>mode</code> is not considered by the equality test.
      */
@@ -249,9 +249,9 @@ public class Link extends Properties implements Comparable<Link> {
             return false;
 
         Link l = (Link) o;
-        if (this.type != l.type)
+        if (this.orientation != l.orientation)
             return false;
-        else if (this.type == Type.DIRECTED)
+        else if (this.orientation == Orientation.DIRECTED)
             return (l.source == this.source && l.destination == this.destination);
         else
             return (l.source == this.source && l.destination == this.destination) ||
@@ -269,7 +269,7 @@ public class Link extends Properties implements Comparable<Link> {
      * Returns a string representation of this link.
      */
     public String toString() {
-        if (type == Type.DIRECTED)
+        if (orientation == Orientation.DIRECTED)
             return (source + " --> " + destination);
         else
             return (source + " <--> " + destination);

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Node.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Node.java
@@ -536,7 +536,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * @return The requested link, or <code>null</code> if no such link is found.
      */
     public Link getInLinkFrom(Node n) {
-        return topo.getLink(n, this, true);
+        return topo.getLink(n, this, Link.Orientation.DIRECTED);
     }
 
     /**
@@ -558,7 +558,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * @return The requested link, or <code>null</code> if no such link is found.
      */
     public Link getCommonLinkWith(Node n) {
-        return topo.getLink(this, n);
+        return topo.getLink(this, n, Link.Orientation.UNDIRECTED);
     }
 
     /**
@@ -568,7 +568,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * @return the {@link List} of inbound {@link Link}s.
      */
     public List<Link> getInLinks() {
-        return topo.getLinks(true, this, 2);
+        return topo.getLinks(Link.Orientation.DIRECTED, this, 2);
     }
 
     /**
@@ -582,25 +582,44 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     }
 
     /**
-     * Returns a list containing all undirected links adjacent to this node.
+     * Returns a list containing all links adjacent to this node. The type of
+     * links is determined according to hasDirectedLinks() method of the topology.
      * The returned list can be subsequently modified without effect on the
      * topology.
      * @return the {@link List} of {@link Link}s
      */
     public List<Link> getLinks() {
-        return getLinks(false);
+        return getLinks(topo.getOrientation());
+    }
+
+    /**
+     * Returns a list containing all adjacent links with the specified
+     * {@code orientation}.
+     *
+     * @param orientation the expected orientation of requested links. The
+     *                    returned list can be subsequently modified without
+     *                    effect on the topology.
+     * @return the {@link List} of {@link Link}s
+     */
+    public List<Link> getLinks(Link.Orientation orientation) {
+        return topo.getLinks(orientation, this, 0);
     }
 
     /**
      * Returns a list containing all adjacent links of the specified type.
      *
      * @param directed <code>true</code> for directed, <code>false</code> for
-     *                 undirected. The returned list can be subsequently modified without
-     *                 effect on the topology.
+     *                 undirected. The returned list can be subsequently
+     *                 modified without effect on the topology.
      * @return the {@link List} of {@link Link}s
+     * @deprecated use {@link #getLinks(Link.Orientation)}
      */
+    @Deprecated
     public List<Link> getLinks(boolean directed) {
-        return topo.getLinks(directed, this, 0);
+        Link.Orientation o = (directed
+                ? Link.Orientation.DIRECTED
+                : Link.Orientation.UNDIRECTED);
+        return topo.getLinks(o, this, 0);
     }
 
     /**
@@ -666,7 +685,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      */
     public List<Node> getNeighbors() {
         LinkedHashSet<Node> neighbors = new LinkedHashSet<>();
-        for (Link l : getLinks())
+        for (Link l : getLinks(Link.Orientation.UNDIRECTED))
             neighbors.add(l.getOtherEndpoint(this));
         return new ArrayList<>(neighbors);
     }

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/io/format/plain/PlainTopologySerializer.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/io/format/plain/PlainTopologySerializer.java
@@ -59,8 +59,8 @@ public class PlainTopologySerializer implements TopologySerializer {
         while (data.indexOf("--") > 0) {
             Node n1 = nodeTable.get(data.substring(0, data.indexOf(" ")));
             Node n2 = nodeTable.get(data.substring(data.indexOf(">") + 2, data.indexOf("\n")));
-            Link.Type type = (data.indexOf("<") > 0 && data.indexOf("<") < data.indexOf("\n")) ? Link.Type.UNDIRECTED : Link.Type.DIRECTED;
-            topology.addLink(new Link(n1, n2, type, Link.Mode.WIRED));
+            Link.Orientation orientation = (data.indexOf("<") > 0 && data.indexOf("<") < data.indexOf("\n")) ? Link.Orientation.UNDIRECTED : Link.Orientation.DIRECTED;
+            topology.addLink(new Link(n1, n2, orientation, Link.Mode.WIRED));
             data = data.substring(data.indexOf("\n") + 1);
         }
     }

--- a/lib/jbotsim-core/src/test/java/io/jbotsim/core/OrientationTest.java
+++ b/lib/jbotsim-core/src/test/java/io/jbotsim/core/OrientationTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2008 - 2019, Arnaud Casteigts and the JBotSim contributors <contact@jbotsim.io>
+ *
+ *
+ * This file is part of JBotSim.
+ *
+ * JBotSim is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * JBotSim is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with JBotSim.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package io.jbotsim.core;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.jbotsim.core.Link.Orientation.DIRECTED;
+import static io.jbotsim.core.Link.Orientation.UNDIRECTED;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OrientationTest {
+    private static final Link.Orientation[] ORIENTATIONS = {UNDIRECTED, DIRECTED};
+    private static final int[][] SQUARE_TOPOLOGY = {{0, 1}, {1, 2}, {2, 3}, {3, 0}};
+    private static final int[][] TETRAHEDRON_TOPOLOGY = {
+            {0, 1}, {1, 2}, {2, 0},
+            {0, 3}, {1, 3}, {2, 3}};
+    private static final int[][] TRIANGLE_TOPOLOGY = {{0, 1}, {1, 2}, {2, 0}};
+    private static final int[][] EMPTY_TOPOLOGY = {};
+    private static final int[][] ONE_ARC_TOPOLOGY = {{0, 1}};
+    private static final int[][] LOOP_TOPOLOGY = {{0, 0}, {0,1}, {1,1}};
+
+    static Stream<Arguments> TOPOLOGIES_WITH_LOOPS () {
+        return Stream.of(Arguments.of((Object) LOOP_TOPOLOGY));
+    }
+
+    static Stream<Arguments> TOPOLOGIES_NO_LOOP() {
+        return Stream.of(
+                Arguments.of((Object) ONE_ARC_TOPOLOGY),
+                Arguments.of((Object) TRIANGLE_TOPOLOGY),
+                Arguments.of((Object) SQUARE_TOPOLOGY),
+                Arguments.of((Object) TETRAHEDRON_TOPOLOGY)
+        );
+    }
+
+    static Stream<Arguments> ALL_TOPOLOGIES() {
+        return Stream.of(TOPOLOGIES_NO_LOOP(),
+                         TOPOLOGIES_WITH_LOOPS(),
+                         Stream.of(Arguments.of((Object) EMPTY_TOPOLOGY))).flatMap(i->i);
+    }
+
+    private static Node findOrAddNode(Topology topology, int id) {
+        Node result = topology.findNodeById(id);
+        if (result == null) {
+            result = new Node();
+            result.setID(id);
+            topology.addNode(result);
+        }
+        return result;
+    }
+
+    /*
+     * Create a topology from the specified array of 'edges'. The orientation of
+     * the result is enforced to 'defaultOrientation' and links are created using
+     * 'linksOrientation' orientation.
+     * In order to prevent implicit creation of links, wireless is disabled.
+     */
+    private static Topology buildTopology(int[][] edges,
+                                          Link.Orientation defaultOrientation,
+                                          Link.Orientation linksOrientation) {
+        Topology result = new Topology();
+        result.disableWireless();
+        result.setOrientation(defaultOrientation);
+        for (int[] e : edges) {
+            Node src = findOrAddNode(result, e[0]);
+            Node tgt = findOrAddNode(result, e[1]);
+            Link l = new Link(src, tgt, linksOrientation);
+            result.addLink(l, true);
+        }
+
+        return result;
+    }
+
+    /*
+     * Create a topology from the specified array of 'edges'. The orientation of
+     * the result is enforced to 'defaultOrientation'. Links are created as
+     * links are specified as directed and in both directions i.e {x,y} yields
+     * the creation of links x -> y and y -> x.
+     * In order to prevent implicit creation of links, wireless is disabled.
+     */
+    private static Topology buildBothWaysEdgesTopology(int[][] edges,
+                                                       Link.Orientation defaultOrientation) {
+        Topology result = new Topology();
+        result.disableWireless();
+        result.setOrientation(defaultOrientation);
+        for (int[] e : edges) {
+            Node src = findOrAddNode(result, e[0]);
+            Node tgt = findOrAddNode(result, e[1]);
+            result.addLink(new Link(src, tgt, DIRECTED), true);
+            if (e[0] != e[1])
+                result.addLink(new Link(tgt, src, DIRECTED), true);
+        }
+
+        return result;
+    }
+
+    @Test
+    void checkDefaultOrientation() {
+        assertEquals(Topology.DEFAULT_ORIENTATION, new Topology().getOrientation());
+    }
+
+    @ParameterizedTest
+    @MethodSource("ALL_TOPOLOGIES")
+    @SuppressWarnings("deprecation")
+    void checkSimpleUndirectedTopology(int[][] edges) {
+        Topology tp = buildTopology(edges, UNDIRECTED, UNDIRECTED);
+        assertFalse(tp.hasDirectedLinks());
+        assertFalse(tp.isDirected());
+
+        List<Link> links = tp.getLinks();
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(UNDIRECTED);
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(2 * edges.length, links.size());
+    }
+
+    private int countLoops(Topology tp) {
+        int result = 0;
+        for (Link l : tp.getLinks(UNDIRECTED)) {
+            if (l.source.equals(l.destination))
+                result++;
+        }
+        return result;
+    }
+
+    private boolean hasLoops(Topology tp) {
+        return countLoops(tp) > 0;
+    }
+
+    @ParameterizedTest
+    @MethodSource("TOPOLOGIES_NO_LOOP")
+    @SuppressWarnings("deprecation")
+    void checkSimpleDirectedTopology(int[][] edges) {
+        Topology tp = buildTopology(edges, DIRECTED, DIRECTED);
+        assertTrue(tp.isDirected());
+        assertTrue(tp.hasDirectedLinks());
+
+        List<Link> links = tp.getLinks();
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(UNDIRECTED);
+        assertTrue(links.isEmpty());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(edges.length, links.size());
+    }
+
+    @Test
+    void checkSimpleDirectedEmptyTopology() {
+        Topology tp = buildTopology(EMPTY_TOPOLOGY, DIRECTED, DIRECTED);
+        assertTrue(tp.isDirected());
+        assertTrue(EMPTY_TOPOLOGY.length == 0);
+
+        assertTrue(tp.getLinks().isEmpty());
+        assertTrue(tp.getLinks(UNDIRECTED).isEmpty());
+        assertTrue(tp.getLinks(DIRECTED).isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("TOPOLOGIES_WITH_LOOPS")
+    void checkSimpleDirectedTopologyWithLoops(int[][] edges) {
+        Topology tp = buildTopology(edges, DIRECTED, DIRECTED);
+        assertTrue(tp.isDirected());
+        assertTrue(hasLoops(tp));
+
+        List<Link> links = tp.getLinks();
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(edges.length, links.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("ALL_TOPOLOGIES")
+    @SuppressWarnings("deprecation")
+    void checkMixedDirectedUndirectedTopology(int[][] edges) {
+        Topology tp = buildTopology(edges, DIRECTED, UNDIRECTED);
+        assertTrue(tp.isDirected());
+        assertFalse(tp.hasDirectedLinks());
+
+        List<Link> links = tp.getLinks();
+        assertEquals(2 * edges.length, links.size());
+
+        links = tp.getLinks(UNDIRECTED);
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(2 * edges.length, links.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("TOPOLOGIES_NO_LOOP")
+    @SuppressWarnings("deprecation")
+    void checkMixedUndirectedDirectedTopology(int[][] edges) {
+        Topology tp = buildTopology(edges, UNDIRECTED, DIRECTED);
+        assertFalse(tp.isDirected());
+        assertTrue(tp.hasDirectedLinks());
+
+        List<Link> links = tp.getLinks();
+        assertTrue(links.isEmpty());
+
+        links = tp.getLinks(UNDIRECTED);
+        assertTrue(links.isEmpty());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(edges.length, links.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("TOPOLOGIES_WITH_LOOPS")
+    void checkMixedUndirectedDirectedTopologyWithLoops(int[][] edges) {
+        Topology tp = buildTopology(edges, UNDIRECTED, DIRECTED);
+        assertFalse(tp.isDirected());
+        assertTrue(hasLoops(tp));
+
+        List<Link> links = tp.getLinks(DIRECTED);
+        assertEquals(edges.length, links.size());
+    }
+
+    @Test
+    void checkMixedUndirectedDirectedEmptyTopology() {
+        Topology tp = buildTopology(EMPTY_TOPOLOGY, UNDIRECTED, DIRECTED);
+        assertFalse(tp.isDirected());
+        assertTrue(EMPTY_TOPOLOGY.length == 0);
+
+        assertTrue(tp.getLinks().isEmpty());
+        assertTrue(tp.getLinks(UNDIRECTED).isEmpty());
+        assertTrue(tp.getLinks(DIRECTED).isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("ALL_TOPOLOGIES")
+    @SuppressWarnings("deprecation")
+    void checkBothWaysEdgesUndirectedTopology(int[][] edges) {
+        Topology tp = buildBothWaysEdgesTopology(edges, UNDIRECTED);
+        assertFalse(tp.isDirected());
+        assertFalse(tp.hasDirectedLinks());
+
+        List<Link> links = tp.getLinks();
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(UNDIRECTED);
+        assertEquals(edges.length, links.size());
+
+        links = tp.getLinks(DIRECTED);
+        assertEquals(2 * edges.length-countLoops(tp), links.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("ALL_TOPOLOGIES")
+    void checkEnforcedLinksOrientation(int[][] edges) {
+        for (Link.Orientation to : ORIENTATIONS) {
+            for (Link.Orientation lo : ORIENTATIONS) {
+                Topology tp1 = buildTopology(edges, to, lo);
+                checkLinksOrientation(tp1);
+                Topology tp2 = buildBothWaysEdgesTopology(edges, to);
+                checkLinksOrientation(tp2);
+            }
+        }
+    }
+
+    void checkLinksOrientation(Topology tp) {
+        for (Link l : tp.getLinks()) {
+            assertEquals(tp.getOrientation(), l.orientation);
+            assertEquals(l.isDirected(), l.orientation == DIRECTED);
+        }
+
+        for (Link.Orientation to : ORIENTATIONS) {
+            for (Link l : tp.getLinks(to)) {
+                assertEquals(to, l.orientation);
+                assertEquals(l.isDirected(), l.orientation == DIRECTED);
+            }
+        }
+    }
+}

--- a/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/GridGenerator.java
+++ b/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/GridGenerator.java
@@ -63,16 +63,16 @@ public class GridGenerator extends AbstractGenerator {
 
     protected void addLinks(Topology tp, int nbRows, int nbColumns, Node[][] nodes) {
         if(wired) {
-            Link.Type type = directed ? Link.Type.DIRECTED : Link.Type.UNDIRECTED;
+            Link.Orientation orientation = directed ? Link.Orientation.DIRECTED : Link.Orientation.UNDIRECTED;
             for (int i = 0; i < nbRows; i++) {
                 for (int j = 0; j < nbColumns; j++) {
                     Node n = nodes[i][j];
                     if (i < nbRows - 1) {
-                        Link l = new Link(n, nodes[i + 1][j], type);
+                        Link l = new Link(n, nodes[i + 1][j], orientation);
                         tp.addLink(l);
                     }
                     if (j < nbColumns - 1) {
-                        Link l = new Link(n, nodes[i][j + 1], type);
+                        Link l = new Link(n, nodes[i][j + 1], orientation);
                         tp.addLink(l);
                     }
                 }

--- a/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/KNGenerator.java
+++ b/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/KNGenerator.java
@@ -45,7 +45,7 @@ public class KNGenerator extends RingGenerator {
         if (wired) {
             for (int i = 0; i < nbNodes; i++)
                 for (int j = i + 1; j < nbNodes; j++)
-                    tp.addLink(new Link(nodes[i], nodes[j], Link.Type.UNDIRECTED));
+                    tp.addLink(new Link(nodes[i], nodes[j], Link.Orientation.UNDIRECTED));
         } else {
             for (Node n : nodes) {
                 n.setCommunicationRange(Math.max(getAbsoluteHeight(tp), getAbsoluteWidth(tp)));

--- a/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/LineGenerator.java
+++ b/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/LineGenerator.java
@@ -61,9 +61,9 @@ public class LineGenerator extends AbstractGenerator {
             int nbNodes = getNbNodes();
             Node[] nodes = generateNodes(topology, nbNodes);
             if (wired) {
-                Link.Type type = directed ? Link.Type.DIRECTED : Link.Type.UNDIRECTED;
+                Link.Orientation orientation = directed ? Link.Orientation.DIRECTED : Link.Orientation.UNDIRECTED;
                 for (int i = 1; i < nbNodes; i++) {
-                    topology.addLink(new Link(nodes[i-1], nodes[i], type, Link.Mode.WIRED));
+                    topology.addLink(new Link(nodes[i-1], nodes[i], orientation, Link.Mode.WIRED));
                 }
             }
         } catch (ReflectiveOperationException e) {

--- a/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/RandomLocationsGenerator.java
+++ b/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/RandomLocationsGenerator.java
@@ -50,12 +50,12 @@ public class RandomLocationsGenerator extends AbstractGenerator {
             Node[] nodes = generateNodes(topology, nbNodes);
 
             if (wired) {
-                Link.Type type = directed ? Link.Type.DIRECTED : Link.Type.UNDIRECTED;
+                Link.Orientation orientation = directed ? Link.Orientation.DIRECTED : Link.Orientation.UNDIRECTED;
 
                 for (int i = 0; i < nbNodes; i++)
                     for (int j = i+1; j < nbNodes; j++)
                         if (rnd.nextDouble() > 0.2)
-                            topology.addLink(new Link(nodes[i], nodes[j], type, Link.Mode.WIRED));
+                            topology.addLink(new Link(nodes[i], nodes[j], orientation, Link.Mode.WIRED));
 
             }
         } catch (ReflectiveOperationException e) {

--- a/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/RingGenerator.java
+++ b/lib/jbotsim-extras-common/src/main/java/io/jbotsim/gen/basic/generators/RingGenerator.java
@@ -75,10 +75,10 @@ public class RingGenerator extends AbstractGenerator {
 
     protected void addLinks(Topology tp, int nbNodes, Node[] nodes) {
         if (wired) {
-            Link.Type type = directed ? Link.Type.DIRECTED : Link.Type.UNDIRECTED;
+            Link.Orientation orientation = directed ? Link.Orientation.DIRECTED : Link.Orientation.UNDIRECTED;
             for (int i = 1; i < nbNodes; i++)
-                tp.addLink(new Link(nodes[i - 1], nodes[i], type));
-            tp.addLink(new Link(nodes[nbNodes - 1], nodes[0], type));
+                tp.addLink(new Link(nodes[i - 1], nodes[i], orientation));
+            tp.addLink(new Link(nodes[nbNodes - 1], nodes[0], orientation));
         } else {
             for (int i = 0; i < nbNodes; i++) {
                 Node pred = (i == 0) ? nodes[nbNodes - 1] : nodes[i - 1];

--- a/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/dot/DotTopologySerializer.java
+++ b/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/dot/DotTopologySerializer.java
@@ -106,7 +106,7 @@ public class DotTopologySerializer implements TopologySerializer {
         String edgeOp;
         StringWriter str = new StringWriter();
         PrintWriter out = new PrintWriter(str);
-        if (topology.hasDirectedLinks()) {
+        if (topology.isDirected()) {
             edgeOp = " -> ";
             out.print("digraph");
         } else {
@@ -131,7 +131,7 @@ public class DotTopologySerializer implements TopologySerializer {
         }
 
         for (int i = 0; i < 2; i++) {
-            List<Link> links = topology.getLinks(i == 0);
+            List<Link> links = topology.getLinks(Link.Orientation.DIRECTED);
             for (Link l : links) {
                 int src = 0;
                 if (!l.isDirected() && l.endpoint(1).getID() < l.endpoint(0).getID())
@@ -201,13 +201,13 @@ public class DotTopologySerializer implements TopologySerializer {
             GraphNode gn2 = edge.getNode2();
             Node tgt = nodeTable.get(gn2);
 
-            Link.Type linkType = Link.Type.UNDIRECTED;
+            Link.Orientation linkOrientation = Link.Orientation.UNDIRECTED;
             String isDirected = (String) edge.getAttribute(JBOTSIM_ATTR_IS_DIRECTED);
             if (isDirected != null && Integer.parseInt(isDirected) == 1) {
-                linkType = Link.Type.DIRECTED;
+                linkOrientation = Link.Orientation.DIRECTED;
             }
 
-            if (linkType.equals(Link.Type.UNDIRECTED)) {
+            if (linkOrientation.equals(Link.Orientation.UNDIRECTED)) {
                 if (src.getNeighbors().contains(tgt))
                     continue;
 
@@ -219,7 +219,7 @@ public class DotTopologySerializer implements TopologySerializer {
             } else if (src.getOutLinkTo(tgt) != null) {
                 continue;
             }
-            Link l = new Link(src, tgt, linkType);
+            Link l = new Link(src, tgt, linkOrientation);
             extractAttributes(edge, l);
             tp.addLink(l);
         }

--- a/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/xml/XMLTopologyBuilder.java
+++ b/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/xml/XMLTopologyBuilder.java
@@ -116,7 +116,7 @@ public class XMLTopologyBuilder extends XMLBuilder {
         Element graph = XMLKeys.GRAPH.createElement(doc);
         for (Node n : tp.getNodes())
             addNode(doc, tp, graph, n);
-        for (Link l : tp.getLinks(true))
+        for (Link l : tp.getLinks(Link.Orientation.DIRECTED))
             if (! l.isWireless())
                 addLink(doc, graph, l);
 

--- a/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/xml/XMLTopologyParser.java
+++ b/lib/jbotsim-serialization-common/src/main/java/io/jbotsim/io/format/xml/XMLTopologyParser.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.jbotsim.core.Link.Mode.WIRED;
-import static io.jbotsim.core.Link.Type.DIRECTED;
-import static io.jbotsim.core.Link.Type.UNDIRECTED;
+import static io.jbotsim.core.Link.Orientation.DIRECTED;
+import static io.jbotsim.core.Link.Orientation.UNDIRECTED;
 
 /**
  * Interpreter for an {@link org.w3c.dom.Document XML document} that represents a {@link Topology}.
@@ -220,7 +220,7 @@ public class XMLTopologyParser extends XMLParser {
     }
 
     private static void parseLink(Element e, Topology tp, Map<String, Node> nodeids) throws ParserException {
-        Link.Type type = XMLKeys.DIRECTED_ATTR.getValueFor(e, false) ? DIRECTED : UNDIRECTED;
+        Link.Orientation orientation = XMLKeys.DIRECTED_ATTR.getValueFor(e, false) ? DIRECTED : UNDIRECTED;
 
         Node src = nodeids.get(XMLKeys.SOURCE_ATTR.getValueFor(e));
         if (src == null)
@@ -228,7 +228,7 @@ public class XMLTopologyParser extends XMLParser {
         Node dst = nodeids.get(XMLKeys.DESTINATION_ATTR.getValueFor(e));
         if (dst == null)
             throw new ParserException("unknown node: " + XMLKeys.DESTINATION_ATTR.getValueFor(e));
-        Link l = new Link(src, dst, type, WIRED);
+        Link l = new Link(src, dst, orientation, WIRED);
 
         l.setWidth(XMLKeys.WIDTH_ATTR.getValueFor(e, Link.DEFAULT_WIDTH));
         l.setColor(parseColor(e, Link.DEFAULT_COLOR));

--- a/lib/jbotsim-serialization-common/src/test/java/io/jbotsim/io/format/dot/DotImportExportCoherencyTest.java
+++ b/lib/jbotsim-serialization-common/src/test/java/io/jbotsim/io/format/dot/DotImportExportCoherencyTest.java
@@ -82,7 +82,9 @@ public class DotImportExportCoherencyTest {
         Node[] nodes = tp.getNodes().toArray(new Node[0]);
 
         if (nbNodes == 1) {
-            tp.getLink(nodes[0], nodes[0], rnd.nextBoolean());
+            Link.Orientation orientation = rnd.nextBoolean()
+                    ? Link.Orientation.DIRECTED : Link.Orientation.UNDIRECTED;
+            tp.getLink(nodes[0], nodes[0], orientation);
         } else {
             for (int src = 0; src < nbNodes; src++) {
                 Node srcNode = nodes[src];
@@ -94,12 +96,15 @@ public class DotImportExportCoherencyTest {
                     } while (srcNode == dstNode);
 
 
-                    if (srcNode.getCommonLinkWith(dstNode) == null && srcNode.getOutLinkTo(dstNode) == null &&
+                    if (srcNode.getCommonLinkWith(dstNode) == null &&
+                            srcNode.getOutLinkTo(dstNode) == null &&
                             dstNode.getOutLinkTo(srcNode) == null) {
-                        Link.Type type = rnd.nextBoolean() ? Link.Type.DIRECTED : Link.Type.UNDIRECTED;
-                        tp.addLink(new Link(srcNode, dstNode, type));
+                        Link.Orientation orientation = rnd.nextBoolean()
+                                ? Link.Orientation.DIRECTED
+                                : Link.Orientation.UNDIRECTED;
+                        tp.addLink(new Link(srcNode, dstNode, orientation));
                     } else if (dstNode.getOutLinkTo(dstNode) != null) {
-                        tp.addLink(new Link(srcNode, dstNode, Link.Type.DIRECTED));
+                        tp.addLink(new Link(srcNode, dstNode, Link.Orientation.DIRECTED));
                     }
                 }
             }
@@ -110,8 +115,10 @@ public class DotImportExportCoherencyTest {
 
     public void checkTopologyGraph(Topology tp1, Topology tp2) {
         assertEquals(tp1.getNodes().size(), tp2.getNodes().size());
-        assertEquals(tp1.getLinks(true).size(), tp2.getLinks(true).size());
-        assertEquals(tp1.getLinks(false).size(), tp2.getLinks(false).size());
+        assertEquals(tp1.getLinks(Link.Orientation.DIRECTED).size(),
+                tp2.getLinks(Link.Orientation.DIRECTED).size());
+        assertEquals(tp1.getLinks(Link.Orientation.UNDIRECTED).size(),
+                tp2.getLinks(Link.Orientation.UNDIRECTED).size());
 
         HashMap<Integer, Node> nodes1 = new HashMap<>();
         for (Node n : tp1.getNodes()) {

--- a/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/JTopology.java
+++ b/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/JTopology.java
@@ -164,7 +164,7 @@ public class JTopology extends JPanel implements ActionListener {
         for (BackgroundPainter painter : backgroundPainters)
             painter.paintBackground(uiComponent, topo);
         if (showDrawings) {
-            for (Link l : topo.getLinks(topo.hasDirectedLinks()))
+            for (Link l : topo.getLinks(topo.getOrientation()))
                 for (LinkPainter linkPainter: linkPainters)
                     linkPainter.paintLink(uiComponent, l);
         }

--- a/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/painting/JLinkPainter.java
+++ b/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/painting/JLinkPainter.java
@@ -49,7 +49,7 @@ public class JLinkPainter implements LinkPainter {
         int destX = (int) link.destination.getX(), destY = (int) link.destination.getY();
         g2d.drawLine(srcX, srcY, (srcX + (destX - srcX)), (srcY + (destY - srcY)));
         Topology topology = link.source.getTopology();
-        if (topology.hasDirectedLinks()) { // FIXME sometimes topology is null here
+        if (topology.isDirected()) { // FIXME sometimes topology is null here
             int x = srcX + 4 * (destX - srcX) / 5 - 2;
             int y = srcY + 4 * (destY - srcY) / 5 - 2;
             g2d.drawOval(x, y, 4, 4);


### PR DESCRIPTION
Hi,
I had added to Topology several accessors with the type of links made explicit in the name of the methods:
* getUndirectedLinks, getDirectedLinks  for all links accessors
* getUndirectedLink, getUndirectedLink for the single link accessor.
I also add a new accessor Node.getCommonUndirectedLinkWith.
Replaced methods have been marked as deprecated.
