### PR TITLE
Fix #66 Javadoc errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ As of version 1.0.0, the project will try and follow [Semantic Versioning](https
 ## [Unreleased]
 
 
+### Javadoc errors 
+
+[[issue 66]][issue: #66]
+
+* Prevent some errors in javadoc compilation by specifying UTF-8 encoding for javac and javadoc.
+
+* Also remove some invalid tags (i.e. \<tt\>) from comments. 
+
+[issue: #66]: https://github.com/jbotsim/JBotSim/issues/66
+
 ###  Link class modifications
 
 **Bug fix in Link:**

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ subprojects {
     test {
         useJUnitPlatform()
     }
+
+    compileJava {
+        options.encoding = 'UTF-8'
+    }
 }
 
 task publishToInternalRepository {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -105,6 +105,7 @@ subprojects {
 
     javadoc {
         options.addStringOption('Xdoclint:all', '-quiet')
+        options.encoding = 'UTF-8'
     }
 }
 
@@ -118,6 +119,7 @@ task monolithicJavadoc(type: Javadoc) {
 
     title = "JBotSim Project documentation"
 
+    options.encoding = 'UTF-8'
     classpath = files(subprojects.collect { it.sourceSets.main.compileClasspath })
 }
 

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Clock.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Clock.java
@@ -49,7 +49,7 @@ public abstract class Clock {
     /**
      * Indicates whether the clock is currently running or paused.
      *
-     * @return <tt>true</tt> if running, <tt>false</tt> if paused.
+     * @return <code>true</code> if running, <code>false</code> if paused.
      */
     public abstract boolean isRunning();
 

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/ClockManager.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/ClockManager.java
@@ -105,7 +105,7 @@ public class ClockManager {
     }
 
     /**
-     * Unregisters the specified listener. (The <tt>onClock()</tt> method of this
+     * Unregisters the specified listener. (The <code>onClock()</code> method of this
      * listener will not longer be called.)
      *
      * @param listener The listener to unregister.
@@ -166,7 +166,7 @@ public class ClockManager {
     /**
      * Indicates whether the clock is currently running or paused.
      *
-     * @return <tt>true</tt> if running, <tt>false</tt> if paused or not started.
+     * @return <code>true</code> if running, <code>false</code> if paused or not started.
      */
     public boolean isRunning() {
         if (clock != null)

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Link.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Link.java
@@ -42,16 +42,16 @@ public class Link extends Properties implements Comparable<Link> {
     Color color = DEFAULT_COLOR;
 
     /**
-     * Enumerates the two possible types of a link: <tt>Type.DIRECTED</tt> and
-     * <tt>Type.UNDIRECTED</tt>.
+     * Enumerates the two possible types of a link: <code>Type.DIRECTED</code> and
+     * <code>Type.UNDIRECTED</code>.
      */
     public enum Type {
         DIRECTED, UNDIRECTED
     }
 
     /**
-     * Enumerates the two possible modes of a link: <tt>Mode.WIRED</tt> and
-     * <tt>Mode.WIRELESS</tt>.
+     * Enumerates the two possible modes of a link: <code>Mode.WIRED</code> and
+     * <code>Mode.WIRELESS</code>.
      */
     public enum Mode {
         WIRED, WIRELESS
@@ -68,11 +68,11 @@ public class Link extends Properties implements Comparable<Link> {
      */
     public Node destination;
     /**
-     * The <tt>Type</tt> of this link (directed/undirected)
+     * The <code>Type</code> of this link (directed/undirected)
      */
     public Type type;
     /**
-     * The <tt>Mode</tt> of this link (wired/wireless)
+     * The <code>Mode</code> of this link (wired/wireless)
      */
     public Mode mode;
 
@@ -87,46 +87,46 @@ public class Link extends Properties implements Comparable<Link> {
     }
 
     /**
-     * Creates a wired link of the specified <tt>type</tt> between the nodes
-     * <tt>from</tt> and <tt>to</tt>. The respective order of <tt>from</tt>
-     * and <tt>to</tt> does not matter if the specified type is undirected.
+     * Creates a wired link of the specified <code>type</code> between the nodes
+     * <code>from</code> and <code>to</code>. The respective order of <code>from</code>
+     * and <code>to</code> does not matter if the specified type is undirected.
      *
      * @param from The source node.
      * @param to   The destination node.
-     * @param type The type of the link (<tt>Type.DIRECTED</tt> or
-     *             <tt>Type.UNDIRECTED</tt>).
+     * @param type The type of the link (<code>Type.DIRECTED</code> or
+     *             <code>Type.UNDIRECTED</code>).
      */
     public Link(Node from, Node to, Type type) {
         this(from, to, type, DEFAULT_MODE);
     }
 
     /**
-     * Creates a link with the specified <tt>mode</tt> between the nodes
-     * <tt>from</tt> and <tt>to</tt>. The created link is undirected by
-     * default. The respective order of <tt>from</tt> and <tt>to</tt> does not
+     * Creates a link with the specified <code>mode</code> between the nodes
+     * <code>from</code> and <code>to</code>. The created link is undirected by
+     * default. The respective order of <code>from</code> and <code>to</code> does not
      * matter.
      *
      * @param from The source node.
      * @param to   The destination node.
-     * @param mode The mode of the link (<tt>Mode.WIRED</tt> or
-     *             <tt>Mode.WIRELESS</tt>).
+     * @param mode The mode of the link (<code>Mode.WIRED</code> or
+     *             <code>Mode.WIRELESS</code>).
      */
     public Link(Node from, Node to, Mode mode) {
         this(from, to, DEFAULT_TYPE, mode);
     }
 
     /**
-     * Creates a link of the specified <tt>type</tt> with the specified
-     * <tt>mode</tt> between the nodes from and to. The created link is wired
-     * by default. The respective order of <tt>from</tt> and <tt>to</tt> does
+     * Creates a link of the specified <code>type</code> with the specified
+     * <code>mode</code> between the nodes from and to. The created link is wired
+     * by default. The respective order of <code>from</code> and <code>to</code> does
      * not matter if the type is undirected.
      *
      * @param from The source node.
      * @param to   The destination node.
-     * @param type The type of the link (<tt>Type.DIRECTED</tt> or
-     *             <tt>Type.UNDIRECTED</tt>).
-     * @param mode The mode of the link (<tt>Mode.WIRED</tt> or
-     *             <tt>Mode.WIRELESS</tt>).
+     * @param type The type of the link (<code>Type.DIRECTED</code> or
+     *             <code>Type.UNDIRECTED</code>).
+     * @param mode The mode of the link (<code>Mode.WIRED</code> or
+     *             <code>Mode.WIRELESS</code>).
      */
     public Link(Node from, Node to, Type type, Mode mode) {
         source = from;
@@ -172,7 +172,7 @@ public class Link extends Properties implements Comparable<Link> {
     /**
      * Returns the parent topology of this link, if any.
      *
-     * @return The parent topology, or <tt>null</tt> if the link has none.
+     * @return The parent topology, or <code>null</code> if the link has none.
      */
     public Topology getTopology() {
         return source.getTopology();
@@ -221,18 +221,18 @@ public class Link extends Properties implements Comparable<Link> {
     }
 
     /**
-     * Tests whether the <tt>mode</tt> is WIRELESS.
-     * @return <tt>true</tt> if the link <tt>mode</tt> is WIRELESS,
-     *         <tt>false</tt> otherwise.
+     * Tests whether the <code>mode</code> is WIRELESS.
+     * @return <code>true</code> if the link <code>mode</code> is WIRELESS,
+     *         <code>false</code> otherwise.
      */
     public boolean isWireless() {
         return mode == Mode.WIRELESS;
     }
 
     /**
-     * Tests whether the <tt>type</tt> is DIRECTED.
-     * @return <tt>true</tt> if the link <tt>type</tt> is DIRECTED,
-     *         <tt>false</tt> otherwise.
+     * Tests whether the <code>type</code> is DIRECTED.
+     * @return <code>true</code> if the link <code>type</code> is DIRECTED,
+     *         <code>false</code> otherwise.
      */
     public boolean isDirected() {
         return type == Type.DIRECTED;
@@ -240,9 +240,9 @@ public class Link extends Properties implements Comparable<Link> {
 
     /**
      * Compares the specified object with this link for equality. Returns
-     * <tt>true</tt> if both links have the same <tt>type</tt>
+     * <code>true</code> if both links have the same <code>type</code>
      * (directed/undirected) and the same endpoints (interchangeably if
-     * undirected). The <tt>mode</tt> is not considered by the equality test.
+     * undirected). The <code>mode</code> is not considered by the equality test.
      */
     public boolean equals(Object o) {
         if (o == null)

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Node.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Node.java
@@ -89,7 +89,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     /**
      * Returns the parent {@link Topology} of this node, if any.
      *
-     * @return The parent {@link Topology}, or <tt>null</tt> if the node is orphan.
+     * @return The parent {@link Topology}, or <code>null</code> if the node is orphan.
      */
     public Topology getTopology() {
         return topo;
@@ -327,8 +327,8 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
 
     /**
      * Indicates whether this node has wireless capabilities enabled.
-     * @return <tt>true</tt> if the wireless capabilities are enabled,
-     *         <tt>false</tt> otherwise.
+     * @return <code>true</code> if the wireless capabilities are enabled,
+     *         <code>false</code> otherwise.
      */
     public boolean isWirelessEnabled() {
         return isWirelessEnabled;
@@ -350,8 +350,8 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
 
     /**
      * Set wireless capabilities status
-     * @param enabled the new wireless status: <tt>true</tt> to enable,
-     *         <tt>false</tt> otherwise.
+     * @param enabled the new wireless status: <code>true</code> to enable,
+     *         <code>false</code> otherwise.
      */
     public void setWirelessStatus(boolean enabled) {
         if (enabled == isWirelessEnabled)
@@ -502,7 +502,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * the reference point).
      *
      * @param p The reference {@link Point}.
-     * @param opposite <tt>true</tt> if the new direction should be the opposite of the reference point.
+     * @param opposite <code>true</code> if the new direction should be the opposite of the reference point.
      */
     public void setDirection(Point p, boolean opposite) {
         Point p2 = (Point) p.clone();
@@ -533,7 +533,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * the specified node, if any such link exists.
      *
      * @param n The sender node.
-     * @return The requested link, or <tt>null</tt> if no such link is found.
+     * @return The requested link, or <code>null</code> if no such link is found.
      */
     public Link getInLinkFrom(Node n) {
         return topo.getLink(n, this, true);
@@ -544,7 +544,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * the specified node, if any such link exists.
      *
      * @param n The destination node.
-     * @return The requested link, or <tt>null</tt> if no such link is found.
+     * @return The requested link, or <code>null</code> if no such link is found.
      */
     public Link getOutLinkTo(Node n) {
         return outLinks.get(n);
@@ -555,7 +555,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * specified node, if any such link exists.
      *
      * @param n The node at the opposite endpoint.
-     * @return The requested link, or <tt>null</tt> if no such link is found.
+     * @return The requested link, or <code>null</code> if no such link is found.
      */
     public Link getCommonLinkWith(Node n) {
         return topo.getLink(this, n);
@@ -594,7 +594,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     /**
      * Returns a list containing all adjacent links of the specified type.
      *
-     * @param directed <tt>true</tt> for directed, <tt>false</tt> for
+     * @param directed <code>true</code> for directed, <code>false</code> for
      *                 undirected. The returned list can be subsequently modified without
      *                 effect on the topology.
      * @return the {@link List} of {@link Link}s
@@ -650,7 +650,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     /**
      * Indicates whether this node has at least one neighbor (undirected)
      *
-     * @return <tt>true</tt> if it does, <tt>false</tt> if it does not.
+     * @return <code>true</code> if it does, <code>false</code> if it does not.
      */
     public boolean hasNeighbors() {
         return getLinks().size() > 0;
@@ -699,9 +699,9 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * The content of the
      * message is specified as an object reference, to be passed 'as is' to the
      * destination(s). The effective transmission will occur at the
-     * <tt>x<sup>th</sup></tt> following clock step, where <tt>x</tt> is the
-     * message delay specified by the static method <tt>Message.setMessageDelay
-     * </tt> (1 by default).
+     * <code>x<sup>th</sup></code> following clock step, where <code>x</code> is the
+     * message delay specified by the static method <code>Message.setMessageDelay
+     * </code> (1 by default).
      *
      * @param destination The destination node.
      * @param message     The message to be sent.
@@ -712,7 +712,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     }
 
     /**
-     * Same as <tt>send()</tt>, but the content is directly given as parameter
+     * Same as <code>send()</code>, but the content is directly given as parameter
      * (a message will be created to contain it).
      *
      * @param destination The non-null destination.
@@ -726,9 +726,9 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     }
 
     /**
-     * Same method as <tt>send()</tt>, but retries to send the message later
+     * Same method as <code>send()</code>, but retries to send the message later
      * if the link to the destination disappeared during transmission.
-     * (Does not work for <tt>null</tt> destinations.)
+     * (Does not work for <code>null</code> destinations.)
      *
      * @param destination The non-null destination.
      * @param message     The message.
@@ -741,7 +741,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     }
 
     /**
-     * Same as <tt>sendRetry()</tt>, but the content is directly given as parameter
+     * Same as <code>sendRetry()</code>, but the content is directly given as parameter
      * (a message will be created to contain it).
      *
      * @param destination The non-null destination.
@@ -758,9 +758,9 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
      * Sends a message to all neighbors. The content of the
      * message is specified as an object reference, to be passed 'as is' to the
      * destination(s). The effective transmission will occur at the
-     * <tt>x<sup>th</sup></tt> following clock step, where <tt>x</tt> is the
-     * message delay specified by the static method <tt>Message.setMessageDelay
-     * </tt> (1 by default).
+     * <code>x<sup>th</sup></code> following clock step, where <code>x</code> is the
+     * message delay specified by the static method <code>Message.setMessageDelay
+     * </code> (1 by default).
      *
      * @param message The message to be sent.
      */
@@ -769,7 +769,7 @@ public class Node extends Properties implements ClockListener, Comparable<Node> 
     }
 
     /**
-     * Same as <tt>sendAll()</tt>, but the content is directly given as parameter
+     * Same as <code>sendAll()</code>, but the content is directly given as parameter
      * (a message will be created to contain it).
      *
      * @param content The object to be sent.

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Properties.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Properties.java
@@ -60,8 +60,8 @@ public abstract class Properties {
     }
 
     /**
-     * Stores the specified property (<tt>value</tt>) under the specified name
-     * (<tt>key</tt>).
+     * Stores the specified property (<code>value</code>) under the specified name
+     * (<code>key</code>).
      *
      * @param key   The property name.
      * @param value The property value.
@@ -85,7 +85,7 @@ public abstract class Properties {
      * Returns the property stored under the specified key.
      *
      * @param key The property key.
-     * @return <tt>true</tt> is the provided key corresponds to a known propery, <tt>false</tt> otherwise.
+     * @return <code>true</code> is the provided key corresponds to a known propery, <code>false</code> otherwise.
      */
     public boolean hasProperty(String key) {
         return properties.containsKey(key);

--- a/lib/jbotsim-core/src/main/java/io/jbotsim/core/Topology.java
+++ b/lib/jbotsim-core/src/main/java/io/jbotsim/core/Topology.java
@@ -206,8 +206,8 @@ public class Topology extends Properties implements ClockListener {
 
     /**
      * Set wireless capabilities status
-     * @param enabled the new wireless status: <tt>true</tt> to enable,
-     *         <tt>false</tt> otherwise.
+     * @param enabled the new wireless status: <code>true</code> to enable,
+     *         <code>false</code> otherwise.
      */
     public void setWirelessStatus(boolean enabled) {
         if (enabled == isWirelessEnabled)
@@ -219,8 +219,8 @@ public class Topology extends Properties implements ClockListener {
 
     /**
      * Returns true if wireless links are enabled.
-     * @return <tt>true</tt> if the wireless links are enabled,
-     *         <tt>false</tt> otherwise.
+     * @return <code>true</code> if the wireless links are enabled,
+     *         <code>false</code> otherwise.
      */
     public boolean getWirelessStatus() {
         return isWirelessEnabled;
@@ -348,7 +348,7 @@ public class Topology extends Properties implements ClockListener {
     /**
      * Indicates whether the internal clock is currently running or in pause.
      *
-     * @return <tt>true</tt> if running, <tt>false</tt> if paused.
+     * @return <code>true</code> if running, <code>false</code> if paused.
      */
     public boolean isRunning() {
         return clockManager.isRunning();
@@ -464,7 +464,7 @@ public class Topology extends Properties implements ClockListener {
 
     /**
      * Adds the specified node to this topology. The location of the node
-     * in the topology will be its current inherent location (or <tt>(0,0)</tt>
+     * in the topology will be its current inherent location (or <code>(0,0)</code>
      * if no location was prealably given to it).
      *
      * @param n The node to be added.
@@ -568,7 +568,7 @@ public class Topology extends Properties implements ClockListener {
      * communication ranges.
      *
      * @param l The link to be added.
-     * @param silent <tt>true</tt> to disable notifications of this adding.
+     * @param silent <code>true</code> to disable notifications of this adding.
      */
     public void addLink(Link l, boolean silent) {
         if (l.type == Type.DIRECTED) {
@@ -639,7 +639,7 @@ public class Topology extends Properties implements ClockListener {
 
     /**
      * Returns true if this topology has at least one directed link.
-     * @return <tt>true</tt> if the {@link Topology} has at least one directed link, <tt>false</tt> otherwise.
+     * @return <code>true</code> if the {@link Topology} has at least one directed link, <code>false</code> otherwise.
      */
     public boolean hasDirectedLinks() {
         return arcs.size() > 2 * edges.size();
@@ -693,7 +693,7 @@ public class Topology extends Properties implements ClockListener {
      * topology. The returned ArrayList can be subsequently modified without
      * effect on the topology.
      *
-     * @param directed <tt>true</tt> for directed links, <tt>false</tt> for
+     * @param directed <code>true</code> for directed links, <code>false</code> for
      *                 undirected links.
      * @return the {@link List} of {@link Link}s.
      */
@@ -727,7 +727,7 @@ public class Topology extends Properties implements ClockListener {
      *
      * @param n1 the first {@link Node}.
      * @param n2 the second {@link Node}.
-     * @return The requested link, if such a link exists, <tt>null</tt>
+     * @return The requested link, if such a link exists, <code>null</code>
      * otherwise.
      */
     public Link getLink(Node n1, Node n2) {
@@ -739,9 +739,9 @@ public class Topology extends Properties implements ClockListener {
      * any.
      * @param from the source {@link Node}.
      * @param to the destination {@link Node}.
-     * @param directed <tt>true</tt> if the searched {@link Link} is directed, <tt>false</tt> otherwise.
+     * @param directed <code>true</code> if the searched {@link Link} is directed, <code>false</code> otherwise.
      *
-     * @return The requested link, if such a link exists, <tt>null</tt>
+     * @return The requested link, if such a link exists, <code>null</code>
      * otherwise.
      */
     public Link getLink(Node from, Node to, boolean directed) {
@@ -790,8 +790,8 @@ public class Topology extends Properties implements ClockListener {
      * added or removed.
      *
      * @param listener The listener to register.
-     * @param directed The type of links to be listened (<tt>true</tt> for
-     *                 directed, <tt>false</tt> for undirected).
+     * @param directed The type of links to be listened (<code>true</code> for
+     *                 directed, <code>false</code> for undirected).
      */
     public void addConnectivityListener(ConnectivityListener listener, boolean directed) {
         if (directed)
@@ -816,7 +816,7 @@ public class Topology extends Properties implements ClockListener {
      *
      * @param listener The listener to unregister.
      * @param directed The type of links that this listener was listening
-     *                 (<tt>true</tt> for directed, <tt>false</tt> for undirected).
+     *                 (<code>true</code> for directed, <code>false</code> for undirected).
      */
     public void removeConnectivityListener(ConnectivityListener listener, boolean directed) {
         if (directed)
@@ -941,7 +941,7 @@ public class Topology extends Properties implements ClockListener {
     }
 
     /**
-     * Unregisters the specified listener. (The <tt>onClock()</tt> method of this
+     * Unregisters the specified listener. (The <code>onClock()</code> method of this
      * listener will not longer be called.)
      *
      * @param listener The listener to unregister.

--- a/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/JViewer.java
+++ b/lib/jbotsim-ui-swing/src/main/java/io/jbotsim/ui/JViewer.java
@@ -62,12 +62,12 @@ public class JViewer implements CommandListener, ChangeListener, PropertyListene
     }
 
     /**
-     * Creates a viewer for the specified topology. If <tt>selfContained</tt>
-     * is <tt>true</tt>, a new window will be created to contain the viewer
-     * (similarly to <tt>JViewer(Topology)</tt>). If it is <tt>false</tt>,
+     * Creates a viewer for the specified topology. If <code>selfContained</code>
+     * is <code>true</code>, a new window will be created to contain the viewer
+     * (similarly to <code>JViewer(Topology)</code>). If it is <code>false</code>,
      * no window will be created and the viewer can be subsequently
-     * integrated to another swing container (e.g. another <tt>JFrame</tt>
-     * or a <tt>JApplet</tt>).
+     * integrated to another swing container (e.g. another <code>JFrame</code>
+     * or a <code>JApplet</code>).
      *
      * @param topo          The topology to be drawn and/or manipulated.
      * @param selfContained Set this to false to avoid creating a JFrame
@@ -89,11 +89,11 @@ public class JViewer implements CommandListener, ChangeListener, PropertyListene
 
     /**
      * Creates a viewer encapsulating the specified jtopology. If
-     * <tt>selfContained</tt> is <tt>true</tt>, a new window will be created
-     * to contain the viewer (similarly to <tt>JViewer(Topology)</tt>). If it
-     * is <tt>false</tt>, no window will be created and the viewer can be
+     * <code>selfContained</code> is <code>true</code>, a new window will be created
+     * to contain the viewer (similarly to <code>JViewer(Topology)</code>). If it
+     * is <code>false</code>, no window will be created and the viewer can be
      * subsequently integrated to another swing container (e.g. another
-     * <tt>JFrame</tt> or a <tt>JApplet</tt>).
+     * <code>JFrame</code> or a <code>JApplet</code>).
      *
      * @param jtopo    The JTopology to be encapsulated.
      * @param windowed Set this to false to avoid creating a JFrame


### PR DESCRIPTION
Minor changes that specify character encoding for the java/javadoc compilers.
Faulty html tags have also been removed.