### PR TITLE
Fix: enforce distribution to prevent problem with oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 script: ./gradlew lib:cleans lib:jars lib:tests
 jdk:


### PR DESCRIPTION
Hi,

Small fix to prevent Travis having faulty behaviors with oraclejdK8.

Thanks.